### PR TITLE
Add xposed scope for Spotify

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         <meta-data android:name="xposedmodule" android:value="true"/>
         <meta-data android:name="xposeddescription" android:value="Enhance Spotify with cool stuff"/>
         <meta-data android:name="xposedminversion" android:value="82"/>
+        <meta-data android:name="xposedscope" android:value="com.spotify.music"/>
     </application>
 
 </manifest>


### PR DESCRIPTION
Added xposed scope to AndroidManifest.xml, so Spotify shows up as recommended in the LSPosed manager